### PR TITLE
add some ai generated & tweaked parser tests

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -243,3 +243,420 @@ pub(crate) fn token_literal_string(string: &[u8]) -> TokenResult {
         Ok((Token::LiteralString(string.into()), b""))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_prefix() {
+        let pattern = parse("/Users/fdncred/src");
+        println!("{:?}\n", pattern.components); // Debug print to inspect the components
+
+        assert_eq!(pattern.components.len(), 4);
+
+        if let PatternComponent::RootDir = &pattern.components[0] {
+            // Expected
+        } else {
+            panic!(
+                "Expected RootDir component, found {:?}",
+                pattern.components[0]
+            );
+        }
+
+        if let PatternComponent::Normal(tokens) = &pattern.components[1] {
+            assert_eq!(tokens.0.len(), 1);
+            if let Token::LiteralString(literal) = &tokens.0[0] {
+                assert_eq!(literal, b"Users");
+            } else {
+                panic!("Expected LiteralString token, found {:?}", tokens.0[0]);
+            }
+        } else {
+            panic!(
+                "Expected Normal component, found {:?}",
+                pattern.components[1]
+            );
+        }
+
+        if let PatternComponent::Normal(tokens) = &pattern.components[2] {
+            assert_eq!(tokens.0.len(), 1);
+            if let Token::LiteralString(literal) = &tokens.0[0] {
+                assert_eq!(literal, b"fdncred");
+            } else {
+                panic!("Expected LiteralString token, found {:?}", tokens.0[0]);
+            }
+        } else {
+            panic!(
+                "Expected Normal component, found {:?}",
+                pattern.components[1]
+            );
+        }
+
+        if let PatternComponent::Normal(tokens) = &pattern.components[3] {
+            assert_eq!(tokens.0.len(), 1);
+            if let Token::LiteralString(literal) = &tokens.0[0] {
+                assert_eq!(literal, b"src");
+            } else {
+                panic!("Expected LiteralString token, found {:?}", tokens.0[0]);
+            }
+        } else {
+            panic!(
+                "Expected Normal component, found {:?}",
+                pattern.components[2]
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_root_dir() {
+        let pattern = parse("/");
+        assert_eq!(pattern.components.len(), 1);
+        assert!(matches!(pattern.components[0], PatternComponent::RootDir));
+    }
+
+    #[test]
+    fn test_parse_cur_dir() {
+        let pattern = parse("./");
+        assert_eq!(pattern.components.len(), 1);
+        assert!(matches!(pattern.components[0], PatternComponent::CurDir));
+    }
+
+    #[test]
+    fn test_parse_parent_dir() {
+        let pattern = parse("../");
+        assert_eq!(pattern.components.len(), 1);
+        assert!(matches!(pattern.components[0], PatternComponent::ParentDir));
+    }
+
+    #[test]
+    fn test_parse_recurse() {
+        let pattern = parse("**");
+        assert_eq!(pattern.components.len(), 1);
+        assert!(matches!(pattern.components[0], PatternComponent::Recurse));
+    }
+
+    #[test]
+    fn test_parse_normal() {
+        let pattern = parse("src");
+        assert_eq!(pattern.components.len(), 1);
+        if let PatternComponent::Normal(tokens) = &pattern.components[0] {
+            assert_eq!(tokens.0.len(), 1);
+            if let Token::LiteralString(literal) = &tokens.0[0] {
+                assert_eq!(literal, b"src");
+            } else {
+                panic!("Expected LiteralString token");
+            }
+        } else {
+            panic!("Expected Normal component");
+        }
+    }
+
+    #[test]
+    fn test_token_any_character() {
+        let (token, remaining) = token_any_character(b"?rest").unwrap();
+        assert!(matches!(token, Token::AnyCharacter));
+        assert_eq!(remaining, b"rest");
+    }
+
+    #[test]
+    fn test_token_wildcard() {
+        let (token, remaining) = token_wildcard(b"*rest").unwrap();
+        assert!(matches!(token, Token::Wildcard));
+        assert_eq!(remaining, b"rest");
+    }
+
+    #[test]
+    fn test_token_alternatives() {
+        let (token, remaining) = token_alternatives(b"{a,b}rest").unwrap();
+        if let Token::Alternatives(alts) = token {
+            assert_eq!(alts.len(), 2);
+            assert_eq!(alts[0].0.len(), 1);
+            assert_eq!(alts[1].0.len(), 1);
+            if let Token::LiteralString(literal) = &alts[0].0[0] {
+                assert_eq!(literal, b"a");
+            } else {
+                panic!("Expected LiteralString token");
+            }
+            if let Token::LiteralString(literal) = &alts[1].0[0] {
+                assert_eq!(literal, b"b");
+            } else {
+                panic!("Expected LiteralString token");
+            }
+        } else {
+            panic!("Expected Alternatives token");
+        }
+        assert_eq!(remaining, b"rest");
+    }
+
+    #[test]
+    fn test_token_character_class() {
+        let (token, remaining) = token_character_class(b"[a-z]rest").unwrap();
+        if let Token::Characters(classes) = token {
+            assert_eq!(classes.len(), 1);
+            if let CharacterClass::Range(start, end) = &classes[0] {
+                assert_eq!(*start, 'a');
+                assert_eq!(*end, 'z');
+            } else {
+                panic!("Expected Range character class");
+            }
+        } else {
+            panic!("Expected Characters token");
+        }
+        assert_eq!(remaining, b"rest");
+    }
+
+    #[test]
+    fn test_token_repeat() {
+        let (token, remaining) = token_repeat(b"<a:2>rest").unwrap();
+        if let Token::Repeat { tokens, min, max } = token {
+            assert_eq!(min, 2);
+            assert_eq!(max, 2);
+            assert_eq!(tokens.0.len(), 1);
+            if let Token::LiteralString(literal) = &tokens.0[0] {
+                assert_eq!(literal, b"a");
+            } else {
+                panic!("Expected LiteralString token");
+            }
+        } else {
+            panic!("Expected Repeat token");
+        }
+        assert_eq!(remaining, b"rest");
+    }
+
+    #[test]
+    fn test_token_literal_string() {
+        let (token, remaining) = token_literal_string(b"literal*rest").unwrap();
+        if let Token::LiteralString(literal) = token {
+            assert_eq!(literal, b"literal");
+        } else {
+            panic!("Expected LiteralString token");
+        }
+        assert_eq!(remaining, b"*rest");
+    }
+
+    #[test]
+    fn test_parse_glob_wildcard() {
+        let pattern = parse("src/*");
+        assert_eq!(pattern.components.len(), 2);
+        if let PatternComponent::Normal(tokens) = &pattern.components[1] {
+            assert_eq!(tokens.0.len(), 1);
+            assert!(matches!(tokens.0[0], Token::Wildcard));
+        } else {
+            panic!("Expected Normal component with Wildcard token");
+        }
+    }
+
+    #[test]
+    fn test_parse_glob_any_character() {
+        let pattern = parse("src/fi?e");
+        assert_eq!(pattern.components.len(), 2);
+        if let PatternComponent::Normal(tokens) = &pattern.components[1] {
+            assert_eq!(tokens.0.len(), 3);
+            assert!(matches!(tokens.0[1], Token::AnyCharacter));
+        } else {
+            panic!("Expected Normal component with AnyCharacter token");
+        }
+    }
+
+    #[test]
+    fn test_parse_glob_alternatives() {
+        let pattern = parse("src/{file,dir}");
+        assert_eq!(pattern.components.len(), 2);
+        if let PatternComponent::Normal(tokens) = &pattern.components[1] {
+            assert_eq!(tokens.0.len(), 1);
+            if let Token::Alternatives(alts) = &tokens.0[0] {
+                assert_eq!(alts.len(), 2);
+                assert_eq!(alts[0].0.len(), 1);
+                assert_eq!(alts[1].0.len(), 1);
+                if let Token::LiteralString(literal) = &alts[0].0[0] {
+                    assert_eq!(literal, b"file");
+                } else {
+                    panic!("Expected LiteralString token");
+                }
+                if let Token::LiteralString(literal) = &alts[1].0[0] {
+                    assert_eq!(literal, b"dir");
+                } else {
+                    panic!("Expected LiteralString token");
+                }
+            } else {
+                panic!("Expected Alternatives token");
+            }
+        } else {
+            panic!("Expected Normal component with Alternatives token");
+        }
+    }
+
+    #[test]
+    fn test_parse_glob_character_class() {
+        let pattern = parse("src/[a-z]ile");
+        assert_eq!(pattern.components.len(), 2);
+        if let PatternComponent::Normal(tokens) = &pattern.components[1] {
+            assert_eq!(tokens.0.len(), 2);
+            if let Token::Characters(classes) = &tokens.0[0] {
+                assert_eq!(classes.len(), 1);
+                if let CharacterClass::Range(start, end) = &classes[0] {
+                    assert_eq!(*start, 'a');
+                    assert_eq!(*end, 'z');
+                } else {
+                    panic!("Expected Range character class");
+                }
+            } else {
+                panic!("Expected Characters token");
+            }
+        } else {
+            panic!("Expected Normal component with Characters token");
+        }
+    }
+
+    #[test]
+    fn test_parse_glob_repeat() {
+        let pattern = parse("src/<a:2>");
+        assert_eq!(pattern.components.len(), 2);
+        if let PatternComponent::Normal(tokens) = &pattern.components[1] {
+            assert_eq!(tokens.0.len(), 1);
+            if let Token::Repeat { tokens, min, max } = &tokens.0[0] {
+                assert_eq!(*min, 2);
+                assert_eq!(*max, 2);
+                assert_eq!(tokens.0.len(), 1);
+                if let Token::LiteralString(literal) = &tokens.0[0] {
+                    assert_eq!(literal, b"a");
+                } else {
+                    panic!("Expected LiteralString token");
+                }
+            } else {
+                panic!("Expected Repeat token");
+            }
+        } else {
+            panic!("Expected Normal component with Repeat token");
+        }
+    }
+
+    #[test]
+    fn test_parse_glob_single_character() {
+        let pattern = parse("src/f?le");
+        assert_eq!(pattern.components.len(), 2);
+        if let PatternComponent::Normal(tokens) = &pattern.components[1] {
+            assert_eq!(tokens.0.len(), 3);
+            assert!(matches!(tokens.0[1], Token::AnyCharacter));
+        } else {
+            panic!("Expected Normal component with AnyCharacter token");
+        }
+    }
+
+    #[test]
+    fn test_parse_glob_multiple_wildcards() {
+        let pattern = parse("src/*/file/*");
+        assert_eq!(pattern.components.len(), 4);
+        if let PatternComponent::Normal(tokens) = &pattern.components[1] {
+            assert_eq!(tokens.0.len(), 1);
+            assert!(matches!(tokens.0[0], Token::Wildcard));
+        } else {
+            panic!("Expected Normal component with Wildcard token");
+        }
+        if let PatternComponent::Normal(tokens) = &pattern.components[3] {
+            assert_eq!(tokens.0.len(), 1);
+            assert!(matches!(tokens.0[0], Token::Wildcard));
+        } else {
+            panic!("Expected Normal component with Wildcard token");
+        }
+    }
+
+    // This one may be too crazy, nested alternatives?
+    // #[test]
+    // fn test_parse_glob_nested_alternatives() {
+    //     let pattern = parse("src/{file,dir/{sub1,sub2}}");
+    //     assert_eq!(pattern.components.len(), 2);
+    //     if let PatternComponent::Normal(tokens) = &pattern.components[1] {
+    //         assert_eq!(tokens.0.len(), 1);
+    //         if let Token::Alternatives(alts) = &tokens.0[0] {
+    //             assert_eq!(alts.len(), 2);
+    //             assert_eq!(alts[0].0.len(), 1);
+    //             assert_eq!(alts[1].0.len(), 1);
+    //             if let Token::LiteralString(literal) = &alts[0].0[0] {
+    //                 assert_eq!(literal, b"file");
+    //             } else {
+    //                 panic!("Expected LiteralString token");
+    //             }
+    //             if let Token::Alternatives(sub_alts) = &alts[1].0[0] {
+    //                 assert_eq!(sub_alts.len(), 2);
+    //                 if let Token::LiteralString(literal) = &sub_alts[0].0[0] {
+    //                     assert_eq!(literal, b"sub1");
+    //                 } else {
+    //                     panic!("Expected LiteralString token");
+    //                 }
+    //                 if let Token::LiteralString(literal) = &sub_alts[1].0[0] {
+    //                     assert_eq!(literal, b"sub2");
+    //                 } else {
+    //                     panic!("Expected LiteralString token");
+    //                 }
+    //             } else {
+    //                 panic!("Expected Alternatives token");
+    //             }
+    //         } else {
+    //             panic!("Expected Alternatives token");
+    //         }
+    //     } else {
+    //         panic!("Expected Normal component with Alternatives token");
+    //     }
+    // }
+
+    #[test]
+    fn test_parse_glob_complex_pattern() {
+        let pattern = parse("src/{file,dir}/[a-z]*.{rs,txt}");
+        assert_eq!(pattern.components.len(), 3);
+        if let PatternComponent::Normal(tokens) = &pattern.components[1] {
+            assert_eq!(tokens.0.len(), 1);
+            if let Token::Alternatives(alts) = &tokens.0[0] {
+                assert_eq!(alts.len(), 2);
+                assert_eq!(alts[0].0.len(), 1);
+                assert_eq!(alts[1].0.len(), 1);
+                if let Token::LiteralString(literal) = &alts[0].0[0] {
+                    assert_eq!(literal, b"file");
+                } else {
+                    panic!("Expected LiteralString token");
+                }
+                if let Token::LiteralString(literal) = &alts[1].0[0] {
+                    assert_eq!(literal, b"dir");
+                } else {
+                    panic!("Expected LiteralString token");
+                }
+            } else {
+                panic!("Expected Alternatives token");
+            }
+        } else {
+            panic!("Expected Normal component with Alternatives token");
+        }
+        if let PatternComponent::Normal(tokens) = &pattern.components[2] {
+            assert_eq!(tokens.0.len(), 4);
+            if let Token::Characters(classes) = &tokens.0[0] {
+                assert_eq!(classes.len(), 1);
+                if let CharacterClass::Range(start, end) = &classes[0] {
+                    assert_eq!(*start, 'a');
+                    assert_eq!(*end, 'z');
+                } else {
+                    panic!("Expected Range character class");
+                }
+            } else {
+                panic!("Expected Characters token");
+            }
+            assert!(matches!(tokens.0[1], Token::Wildcard));
+            if let Token::Alternatives(alts) = &tokens.0[3] {
+                assert_eq!(alts.len(), 2);
+                if let Token::LiteralString(literal) = &alts[0].0[0] {
+                    assert_eq!(literal, b"rs");
+                } else {
+                    panic!("Expected LiteralString token");
+                }
+                if let Token::LiteralString(literal) = &alts[1].0[0] {
+                    assert_eq!(literal, b"txt");
+                } else {
+                    panic!("Expected LiteralString token");
+                }
+            } else {
+                panic!("Expected Alternatives token");
+            }
+        } else {
+            panic!("Expected Normal component with Characters and Alternatives tokens");
+        }
+    }
+}


### PR DESCRIPTION
This PR just adds some ai generated parser tests. one commented out that just doesn't seem to work because it's pretty funky.

Wasn't sure where we wanted these, so I just put them in parser.rs.

They all pass on my mac, but we probably need to add some windows specific tests because the verbatim paths are usually problematic.